### PR TITLE
Fix dependency error for normalize-text

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "feathers-hooks": "^2.0.1",
     "feathers-nedb": "^2.6.2",
     "mocha": "^3.4.2",
-    "nedb": "^1.8.0",
-    "normalize-text": "^0.5.0"
+    "nedb": "^1.8.0"
   },
   "dependencies": {
     "deep-reduce": "^1.0.5",
     "escape-string-regexp": "^1.0.5",
     "object-path": "^0.11.4",
     "feathers-commons": "^0.8.7",
-    "feathers-errors": "^2.9.1"
+    "feathers-errors": "^2.9.1",
+    "normalize-text": "^0.5.0"
   },
   "runkitExampleFilename": "example.js"
 }


### PR DESCRIPTION
`normalize-text` should be regular dependency instead of a dev dependency.

may conflict with #5 but wanted to keep each issue contained to its own PR